### PR TITLE
Feature/additional liquid tracers jmaerz

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -57,6 +57,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['lnd_grid'] = case.get_value("LND_GRID")
     config['rof_ncpl'] = case.get_value("ROF_NCPL")
     config['simyr'] = case.get_value("MOSART_SIM_YEAR")
+    config['mosart_debug'] = "yes" if case.get_value("MOSART_DEBUG") == TRUE else "no"
 
     logger.debug("River Transport Model (MOSART) mode is %s ", config['mosart_mode'])
     logger.debug("  MOSART lnd grid is %s ", config['lnd_grid'])

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -35,6 +35,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     different instances. The `confdir` argument is used to specify the directory
     in which output files will be placed.
     """
+    mosart_debug = case.get_value('MOSART_DEBUG')
+
     #----------------------------------------------------
     # Create config dictionary
     #----------------------------------------------------
@@ -57,7 +59,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['lnd_grid'] = case.get_value("LND_GRID")
     config['rof_ncpl'] = case.get_value("ROF_NCPL")
     config['simyr'] = case.get_value("MOSART_SIM_YEAR")
-    config['mosart_debug'] = "yes" if case.get_value("MOSART_DEBUG") else "no"
+    config['mosart_debug'] = "yes" if (mosart_debug == 'TRUE') else "no"
 
     logger.debug("River Transport Model (MOSART) mode is %s ", config['mosart_mode'])
     logger.debug("  MOSART lnd grid is %s ", config['lnd_grid'])

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -57,7 +57,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['lnd_grid'] = case.get_value("LND_GRID")
     config['rof_ncpl'] = case.get_value("ROF_NCPL")
     config['simyr'] = case.get_value("MOSART_SIM_YEAR")
-    config['mosart_debug'] = "yes" if case.get_value("MOSART_DEBUG") == TRUE else "no"
+    config['mosart_debug'] = "yes" if case.get_value("MOSART_DEBUG") else "no"
 
     logger.debug("River Transport Model (MOSART) mode is %s ", config['mosart_mode'])
     logger.debug("  MOSART lnd grid is %s ", config['lnd_grid'])

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -14,7 +14,7 @@
     <desc option="FLOOD">MOSART model with flood:</desc>
   </description>
 
-  <entry id="COMP_ROF"> 
+  <entry id="COMP_ROF">
      <type>char</type>
      <valid_values>mosart</valid_values>
      <default_value>mosart</default_value>
@@ -70,6 +70,17 @@
     <file>env_run.xml</file>
     <desc>Simulation year to start from -- build-namelist options (currently not used)</desc>
   </entry>
+
+  <entry id="MOSART_DEBUG">
+    <type>char</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_component_mosart</group>
+    <file>env_run.xml</file>
+    <desc>Debug mosart code</desc>
+  </entry>
+
+
   <help>
     =========================================
     MOSART naming conventions

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -280,7 +280,7 @@
     </values>
     <desc>
       Default: .false.
-      This flag turned on will halt the model run, when strange values appear (i.e. negative water volumes)
+      This flag turned on will write out warnings, when strange values appear (i.e. negative water storage)
     </desc>
   </entry>
 

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -276,6 +276,7 @@
     <values>
       <value>.false.</value>
       <value mosart_debug="yes">.true.</value>
+      <value mosart_debug="no">.false.</value>
     </values>
     <desc>
       Default: .false.

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -269,4 +269,18 @@
     </desc>
   </entry>
 
+  <entry id="debug_mosart" modify_via_xml="MOSART_DEBUG" >
+    <type>logical</type>
+    <category>mosart</category>
+    <group>mosart_inparm</group>
+    <values>
+      <value>.false.</value>
+      <value mosart_debug="yes">.true.</value>
+    </values>
+    <desc>
+      Default: .false.
+      This flag turned on will halt the model run, when strange values appear (i.e. negative water volumes)
+    </desc>
+  </entry>
+
 </entry_id>

--- a/src/riverroute/mosart_control_type.F90
+++ b/src/riverroute/mosart_control_type.F90
@@ -154,9 +154,6 @@ contains
     this%nt_liq = 1 ! liquid water
     this%nt_ice = 2 ! ice
 
-    this%tracer_names(this%nt_liq) = 'LIQ'
-    this%tracer_names(this%nt_ice) = 'ICE'
-
     ! Determine number of tracers and array of tracer names
     if (lnd2rof_tracers /= ' ') then
        this%ntracers_nonh2o = shr_string_listGetNum(lnd2rof_tracers)
@@ -166,6 +163,9 @@ contains
     this%ntracers_tot = this%nt_ice + this%ntracers_nonh2o ! liquid water and ice + nonH2O tracers
 
     allocate(this%tracer_names(this%ntracers_tot))
+    
+    this%tracer_names(this%nt_liq) = 'LIQ'
+    this%tracer_names(this%nt_ice) = 'ICE'
 
     ! names of non-water liquid tracers
     do nt = 1,this%ntracers_nonh2o

--- a/src/riverroute/mosart_driver.F90
+++ b/src/riverroute/mosart_driver.F90
@@ -36,6 +36,7 @@ module mosart_driver
    implicit none
    private
 
+
    ! public member functions:
    public :: mosart_read_namelist ! Read in mosart namelist
    public :: mosart_init1         ! Initialize mosart grid
@@ -61,6 +62,9 @@ module mosart_driver
    character(len=CL) :: fnamer              ! name of netcdf restart file
 
    integer :: nt_liq, nt_ice                ! Index for liquid water and ice
+
+   ! debugging
+   logical, public :: debug_mosart = .false.
 
    character(*), parameter :: u_FILE_u = &
         __FILE__
@@ -90,7 +94,7 @@ contains
       namelist /mosart_inparm / frivinp, finidat, nrevsn, coupling_period, ice_runoff, &
            ndens, mfilt, nhtfrq, fincl1,  fincl2, fincl3, fexcl1,  fexcl2, fexcl3, &
            avgflag_pertape, decomp_option, bypass_routing_option, qgwl_runoff_option, &
-           use_halo_option, delt_mosart, budget_frq
+           use_halo_option, delt_mosart, budget_frq,debug_mosart
 
       ! Preset values
       ice_runoff  = .true.

--- a/src/riverroute/mosart_driver.F90
+++ b/src/riverroute/mosart_driver.F90
@@ -12,7 +12,8 @@ module mosart_driver
                                         frivinp, nsrContinue, nsrBranch, nsrStartup, nsrest, &
                                         inst_index, inst_suffix, inst_name, decomp_option, &
                                         bypass_routing_option, qgwl_runoff_option, barrier_timers, &
-                                        mainproc, npes, iam, mpicom_rof, budget_frq, isecspday
+                                        mainproc, npes, iam, mpicom_rof, budget_frq, isecspday,    &
+                                        debug_mosart
    use mosart_data             , only : ctl, Tctl, Tunit, TRunoff, Tpara
    use mosart_budget_type      , only : budget_type
    use mosart_fileutils        , only : getfil
@@ -62,9 +63,6 @@ module mosart_driver
    character(len=CL) :: fnamer              ! name of netcdf restart file
 
    integer :: nt_liq, nt_ice                ! Index for liquid water and ice
-
-   ! debugging
-   logical, public :: debug_mosart = .false.
 
    character(*), parameter :: u_FILE_u = &
         __FILE__

--- a/src/riverroute/mosart_physics.F90
+++ b/src/riverroute/mosart_physics.F90
@@ -272,7 +272,7 @@ contains
                         if (debug_mosart) then
                           ! check for negative channel storage
                           if(wr(nr,1) < -1.e-10) then
-                            write(iulog,*) 'Negative channel storage! ', nr, wr(nr,1)
+                            write(iulog,*) 'DEBUG: Negative channel storage! ', nr, wr(nr,1)
                             !call shr_sys_abort('mosart: negative channel storage')
                           end if
                         end if
@@ -295,10 +295,12 @@ contains
          call t_stopf('mosartr_chanroute')
       end do
 
-      ! check for negative channel storage
-      if (negchan < -1.e-10) then
-         write(iulog,*) 'Warning: Negative channel storage found! ',negchan
-         ! call shr_sys_abort('mosart: negative channel storage')
+      if (debug_mosart) then
+        ! check for negative channel storage
+        if (negchan < -1.e-10) then
+           write(iulog,*) 'DEBUG: Warning: Negative channel storage found! ',negchan
+           ! call shr_sys_abort('mosart: negative channel storage')
+        endif
       endif
       flow = flow / DLevelH2R
       erout_prev = erout_prev / DLevelH2R
@@ -364,7 +366,7 @@ contains
       if (debug_mosart) then
       ! check stability
         if(vt < -TINYVALUE .or. vt > 30) then
-          write(iulog,*) "Numerical error in subnetworkRouting, ", nr,vt
+          write(iulog,*) "DEBUG: Numerical error in subnetworkRouting, ", nr,vt
         end if
       endif
 
@@ -433,21 +435,21 @@ contains
       dwr = erlateral + erin + erout + temp_gwl
 
       if ((wr/DeltaT + dwr) < -TINYVALUE .and. (trim(bypass_routing_option)/='none') ) then
-         write(iulog,*) 'mosart: ERROR main channel going negative: ', nr
+         write(iulog,*) 'DEBUG: mosart: ERROR main channel going negative: ', nr
          write(iulog,*) DeltaT, wr, wr/DeltaT, dwr, temp_gwl
          write(iulog,*) ' '
       endif
 
       if (debug_mosart) then
-      ! check for stability
+        ! check for stability
         if(vr < -TINYVALUE .or. vr > 30) then
-           write(iulog,*) "Numerical error inRouting_KW, ", nr,vr
+           write(iulog,*) "DEBUG: Numerical error inRouting_KW, ", nr,vr
         end if
 
-      ! check for negative wr
+        ! check for negative wr
         if(wr > 1._r8 .and. (wr/DeltaT + dwr)/wr < -TINYVALUE) then
-           write(iulog,*) 'negative wr!', wr, dwr, temp_gwl, DeltaT
-      !       stop
+           write(iulog,*) 'DEBUG: negative wr!', wr, dwr, temp_gwl, DeltaT
+        !       stop
         end if
       endif
       end associate

--- a/src/riverroute/mosart_physics.F90
+++ b/src/riverroute/mosart_physics.F90
@@ -16,6 +16,7 @@ module mosart_physics
    use nuopc_shr_methods , only : chkerr
    use ESMF              , only : ESMF_FieldGet, ESMF_FieldSMM, ESMF_Finalize, &
                                   ESMF_SUCCESS, ESMF_END_ABORT, ESMF_TERMORDER_SRCSEQ
+   use mosart_driver     , only : debug_mosart
 
    implicit none
    private
@@ -268,11 +269,12 @@ contains
                              erin(nr,nt), erout(nr,nt), vr(nr,nt), dwr(nr,nt))                                 ! output
                         wr(nr,nt) = wr(nr,nt) + dwr(nr,nt) * localDeltaT
 
-                        ! check for negative channel storage
-                        ! if(wr(nr,1) < -1.e-10) then
-                        !    write(iulog,*) 'Negative channel storage! ', nr, wr(nr,1)
-                        !    call shr_sys_abort('mosart: negative channel storage')
-                        ! end if
+                        if (debug_mosart) then
+                          ! check for negative channel storage
+                          if(wr(nr,1) < -1.e-10) then
+                            write(iulog,*) 'Negative channel storage! ', nr, wr(nr,1)
+                            !call shr_sys_abort('mosart: negative channel storage')
+                        end if
 
                         call UpdateState_mainchannel(nr, wr(nr,nt), &    ! input
                              mr(nr,nt), yr(nr,nt), pr(nr,nt), rr(nr,nt)) ! output
@@ -358,10 +360,12 @@ contains
       end if
       dwt = etin + etout
 
+      if (debug_mosart) then
       ! check stability
-      ! if(vt < -TINYVALUE .or. vt > 30) then
-      !    write(iulog,*) "Numerical error in subnetworkRouting, ", nr,vt
-      ! end if
+        if(vt < -TINYVALUE .or. vt > 30) then
+          write(iulog,*) "Numerical error in subnetworkRouting, ", nr,vt
+        end if
+      endif
 
    end subroutine subnetworkRouting
 
@@ -433,17 +437,17 @@ contains
          write(iulog,*) ' '
       endif
 
+      if (debug_mosart) then
       ! check for stability
-      !    if(vr < -TINYVALUE .or. vr > 30) then
-      !       write(iulog,*) "Numerical error inRouting_KW, ", nr,vr
-      !    end if
+        if(vr < -TINYVALUE .or. vr > 30) then
+           write(iulog,*) "Numerical error inRouting_KW, ", nr,vr
+        end if
 
       ! check for negative wr
-      !    if(wr > 1._r8 .and. &
-      !      (wr/DeltaT + dwr)/wr < -TINYVALUE) then
-      !       write(iulog,*) 'negative wr!', wr, dwr, temp_gwl, DeltaT
+        if(wr > 1._r8 .and. (wr/DeltaT + dwr)/wr < -TINYVALUE) then
+           write(iulog,*) 'negative wr!', wr, dwr, temp_gwl, DeltaT
       !       stop
-      !    end if
+        end if
 
       end associate
    end subroutine MainchannelRouting

--- a/src/riverroute/mosart_physics.F90
+++ b/src/riverroute/mosart_physics.F90
@@ -274,6 +274,7 @@ contains
                           if(wr(nr,1) < -1.e-10) then
                             write(iulog,*) 'Negative channel storage! ', nr, wr(nr,1)
                             !call shr_sys_abort('mosart: negative channel storage')
+                          end if
                         end if
 
                         call UpdateState_mainchannel(nr, wr(nr,nt), &    ! input
@@ -448,7 +449,7 @@ contains
            write(iulog,*) 'negative wr!', wr, dwr, temp_gwl, DeltaT
       !       stop
         end if
-
+      endif
       end associate
    end subroutine MainchannelRouting
 

--- a/src/riverroute/mosart_physics.F90
+++ b/src/riverroute/mosart_physics.F90
@@ -10,13 +10,13 @@ module mosart_physics
    use shr_kind_mod      , only : r8 => shr_kind_r8
    use shr_const_mod     , only : SHR_CONST_REARTH, SHR_CONST_PI
    use shr_sys_mod       , only : shr_sys_abort
-   use mosart_vars       , only : iulog, barrier_timers, mpicom_rof, bypass_routing_option
+   use mosart_vars       , only : iulog, barrier_timers, mpicom_rof, bypass_routing_option,        &
+                                  debug_mosart
    use mosart_data       , only : Tctl, TUnit, TRunoff, TPara, ctl
    use perf_mod          , only : t_startf, t_stopf
    use nuopc_shr_methods , only : chkerr
    use ESMF              , only : ESMF_FieldGet, ESMF_FieldSMM, ESMF_Finalize, &
                                   ESMF_SUCCESS, ESMF_END_ABORT, ESMF_TERMORDER_SRCSEQ
-   use mosart_driver     , only : debug_mosart
 
    implicit none
    private

--- a/src/riverroute/mosart_vars.F90
+++ b/src/riverroute/mosart_vars.F90
@@ -39,6 +39,8 @@ module mosart_vars
    character(len=CS)  :: bypass_routing_option  ! bypass routing model method
    character(len=CS)  :: qgwl_runoff_option     ! method for handling qgwl runoff
    integer            :: budget_frq = -24       ! budget check frequency
+   ! debugging
+   logical            :: debug_mosart = .false.
 
    ! Metadata variables used in history and restart generation
    character(len=CL)  :: caseid  = ' '          ! case id


### PR DESCRIPTION
Hi Mariana, I figured it out. This PR introduces a xml-switch do write out warning messages in `mosart_physics`.
Further, it fixes the allocation issue that was introduced yesterday.